### PR TITLE
Potential fix for code scanning alert no. 15: Use of externally-controlled format string

### DIFF
--- a/src/services/monitoring/paymentMonitor.ts
+++ b/src/services/monitoring/paymentMonitor.ts
@@ -20,6 +20,6 @@ export class PaymentMonitor {
   }
 
   static logVerificationFailure(identifier: string, source: string, error: any, registrationId?: string) {
-    console.error(`[PaymentMonitor] Verification failure - ${identifier} from ${source}`, { error, registrationId });
+    console.error("[PaymentMonitor] Verification failure - %s from %s", identifier, source, { error, registrationId });
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/algotouch/algotouch-01/security/code-scanning/15](https://github.com/algotouch/algotouch-01/security/code-scanning/15)

To fix the issue, we will ensure that the untrusted `identifier` and `source` values are passed as separate arguments to `console.error` using a `%s` specifier in the format string. This approach avoids directly interpolating untrusted input into the format string, mitigating the risk of unexpected behavior.

Specifically:
1. Update the `console.error` call in `logVerificationFailure` to use a format string with `%s` placeholders for `identifier` and `source`.
2. Pass `identifier` and `source` as separate arguments to the `console.error` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
